### PR TITLE
Fix build warnings in clang caused by gcc only compile option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -487,8 +487,10 @@ target_compile_options(
   $<$<CXX_COMPILER_ID:MSVC>:/vmg /MP>
   PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
-    -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-stringop-overflow>
-  $<$<CXX_COMPILER_ID:MSVC>:/W3 /wd4244 /wd4267 /wd4996>)
+    -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable>
+  $<$<CXX_COMPILER_ID:GNU>:
+    -Wno-stringop-overflow>
+  $<$<CXX_COMPILER_ID:MSVC>: /W3 /wd4244 /wd4267 /wd4996>)
 
 target_include_directories(systemc
   PUBLIC


### PR DESCRIPTION
addresses #4 