### PR TITLE
feat: adding INSCIGHT_RT_DISABLED env variable

### DIFF
--- a/src/inscight/database.cpp
+++ b/src/inscight/database.cpp
@@ -20,7 +20,7 @@
 
 #if defined(__linux__)
 #include <unistd.h>
-#include<limits.h>
+#include <limits.h>
 #include <signal.h>
 
 static std::string progpath() {
@@ -103,7 +103,7 @@ static std::string username() {
 
 namespace inscight {
 
-static bool rt_trace_enabled = true;
+static volatile sig_atomic_t rt_trace_enabled = nullptr == getenv("INSCIGHT_RT_DISABLED");
 
 #ifdef __linux__
 static void handle_sigusr(int sig) {

--- a/src/inscight/database.cpp
+++ b/src/inscight/database.cpp
@@ -103,7 +103,12 @@ static std::string username() {
 
 namespace inscight {
 
-static volatile sig_atomic_t rt_trace_enabled = nullptr == getenv("INSCIGHT_RT_DISABLED");
+#ifdef __linux__
+static volatile sig_atomic_t rt_trace_enabled =
+    getenv("INSCIGHT_RT_DISABLED") == nullptr ? 1 : 0;
+#else
+static bool rt_trace_enabled = getenv("INSCIGHT_RT_DISABLED") == nullptr;
+#endif
 
 #ifdef __linux__
 static void handle_sigusr(int sig) {


### PR DESCRIPTION
Added a INSCIGHT_RT_DISABLED environment variable that allows to disable tracing when launching the simulation.
Changed the type of the variable `rt_trace_enabled` to `sig_atomic_t` because it [can be changed by asynchronous interrupts](https://en.cppreference.com/c/program/sig_atomic_t).
Also fixed a missing space in the header.
